### PR TITLE
Add overwrite flag

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -61,7 +61,7 @@ func FileExists(name string) bool {
 }
 
 func TranscodeToMP3(originalFile string, destinationFile string, artist string, title string) {
-	args := []string{"-i", originalFile, "-acodec", "libmp3lame", "-ab", "128k", "-metadata", "artist=" + artist, "-metadata", "title=" + title, destinationFile}
+	args := []string{"-i", originalFile, "-acodec", "libmp3lame", "-ab", "128k", "-metadata", "artist=" + artist, "-metadata", "title=" + title, "-y", destinationFile}
 
 	cmd := exec.Command("ffmpeg", args...)
 	var out bytes.Buffer


### PR DESCRIPTION
According to the [ffmpeg docs](https://ffmpeg.org/ffmpeg.html) the '-y' flag usually goes right before the output path, so that's where I placed it. 
